### PR TITLE
New Relic Importing of Tags and alert resources separately (#2008)

### DIFF
--- a/docs/relic.md
+++ b/docs/relic.md
@@ -13,7 +13,16 @@ List of supported New Relic resources:
     * `newrelic_alert_condition`
     * `newrelic_alert_policy`
     * `newrelic_nrql_alert_condition`
+*   `alertchannel`
+    * `newrelic_alert_channel`
+*   `alertcondition`
+    * `newrelic_alert_condition`
+    * `newrelic_nrql_alert_condition`
+*   `alertpolicy`
+    * `newrelic_alert_policy`
 *   `infra`
     * `newrelic_infra_alert_condition`
 *   `synthetics`
     * `newrelic_synthetics_monitor`
+*   `tags`
+    * `newrelic_entity_tags`

--- a/providers/newrelic/alertchannel.go
+++ b/providers/newrelic/alertchannel.go
@@ -1,0 +1,59 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	newrelic "github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+type AlertChannelGenerator struct {
+	NewRelicService
+}
+
+func (g *AlertChannelGenerator) createAlertChannelResources(client *newrelic.NewRelic) error {
+	alertChannels, err := client.Alerts.ListChannels()
+	if err != nil {
+		return err
+	}
+
+	for _, channel := range alertChannels {
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			fmt.Sprintf("%d", channel.ID),
+			fmt.Sprintf("%s-%d", normalizeResourceName(channel.Name), channel.ID),
+			"newrelic_alert_channel",
+			g.ProviderName,
+			[]string{},
+		))
+	}
+
+	return nil
+}
+
+func (g *AlertChannelGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	err = g.createAlertChannelResources(client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/providers/newrelic/alertcondition.go
+++ b/providers/newrelic/alertcondition.go
@@ -1,0 +1,107 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	newrelic "github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+type AlertConditionGenerator struct {
+	NewRelicService
+}
+
+func (g *AlertConditionGenerator) createAlertConditionResources(client *newrelic.NewRelic) error {
+	alertPolicies, err := client.Alerts.ListPolicies(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, alertPolicy := range alertPolicies {
+		alertConditions, err := client.Alerts.ListConditions(alertPolicy.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, alertCondition := range alertConditions {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%d:%d", alertPolicy.ID, alertCondition.ID),
+				fmt.Sprintf("%s-%d", normalizeResourceName(alertCondition.Name), alertCondition.ID),
+				"newrelic_alert_condition",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return nil
+}
+
+func (g *AlertConditionGenerator) createAlertNrqlConditionResources(client *newrelic.NewRelic) error {
+	alertPolicies, err := client.Alerts.ListPolicies(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, alertPolicy := range alertPolicies {
+		nrqlConditions, err := client.Alerts.ListNrqlConditions(alertPolicy.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, nrqlCondition := range nrqlConditions {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprintf("%d:%d", alertPolicy.ID, nrqlCondition.ID),
+				fmt.Sprintf("%s-%d", normalizeResourceName(nrqlCondition.Name), nrqlCondition.ID),
+				"newrelic_nrql_alert_condition",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+	return nil
+}
+
+func (g *AlertConditionGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*newrelic.NewRelic) error{
+		g.createAlertConditionResources,
+		g.createAlertNrqlConditionResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *AlertConditionGenerator) PostConvertHook() error {
+	for i, resource := range g.Resources {
+		if resource.InstanceInfo.Type == "newrelic_alert_condition" {
+			if resource.Item["violation_close_timer"] == "0" {
+				delete(g.Resources[i].Item, "violation_close_timer")
+			}
+		}
+	}
+
+	return nil
+}

--- a/providers/newrelic/alertpolicy.go
+++ b/providers/newrelic/alertpolicy.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	newrelic "github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+type AlertPolicyGenerator struct {
+	NewRelicService
+}
+
+func (g *AlertPolicyGenerator) createAlertPolicyResources(client *newrelic.NewRelic) error {
+	alertPolicies, err := client.Alerts.ListPolicies(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, alertPolicy := range alertPolicies {
+		g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+			fmt.Sprintf("%d", alertPolicy.ID),
+			fmt.Sprintf("%s-%d", normalizeResourceName(alertPolicy.Name), alertPolicy.ID),
+			"newrelic_alert_policy",
+			g.ProviderName,
+			[]string{}))
+	}
+
+	return nil
+}
+
+func (g *AlertPolicyGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	err = g.createAlertPolicyResources(client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/providers/newrelic/newrelic_provider.go
+++ b/providers/newrelic/newrelic_provider.go
@@ -84,8 +84,12 @@ func (NewRelicProvider) GetResourceConnections() map[string]map[string][]string 
 func (p *NewRelicProvider) GetSupportedService() map[string]terraformutils.ServiceGenerator {
 	return map[string]terraformutils.ServiceGenerator{
 		"alert":      &AlertGenerator{},
-		"infra":      &InfraGenerator{},
-		"synthetics": &SyntheticsGenerator{},
+		"alert_channel": &AlertChannelGenerator{},
+		"alert_condition": &AlertConditionGenerator{},
+		"alert_policy":    &AlertPolicyGenerator{},
+		"infra":           &InfraGenerator{},
+		"synthetics":      &SyntheticsGenerator{},
+		"tags":            &TagsGenerator{},
 	}
 }
 

--- a/providers/newrelic/tags.go
+++ b/providers/newrelic/tags.go
@@ -1,0 +1,124 @@
+// Copyright 2019 The Terraformer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newrelic
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraformer/terraformutils"
+	newrelic "github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-client-go/pkg/common"
+)
+
+type TagsGenerator struct {
+	NewRelicService
+}
+
+func (g *TagsGenerator) createSyntheticsMonitorTagResources(client *newrelic.NewRelic) error {
+	allMonitors, err := client.Synthetics.ListMonitors()
+	if err != nil {
+		return err
+	}
+
+	for _, monitor := range allMonitors {
+		allTags, err := client.Entities.GetTagsForEntityMutable(common.EntityGUID(monitor.ID))
+		if err != nil {
+			return err
+		}
+
+		for range allTags {
+			g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+				fmt.Sprint(monitor.ID),
+				fmt.Sprintf("%s-%s", normalizeResourceName(monitor.Name), monitor.ID),
+				"newrelic_entity_tags",
+				g.ProviderName,
+				[]string{}))
+		}
+	}
+
+	return nil
+}
+
+func (g *TagsGenerator) createAlertConditionTagResources(client *newrelic.NewRelic) error {
+	alertPolicies, err := client.Alerts.ListPolicies(nil)
+	if err != nil {
+		return err
+	}
+
+	for _, alertPolicy := range alertPolicies {
+		alertConditions, err := client.Alerts.ListConditions(alertPolicy.ID)
+		if err != nil {
+			return err
+		}
+
+		nrqlConditions, err := client.Alerts.ListNrqlConditions(alertPolicy.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, alertCondition := range alertConditions {
+			allAlertConditionTags, err := client.Entities.GetTagsForEntityMutable(common.EntityGUID(fmt.Sprint(alertCondition.ID)))
+			if err != nil {
+				return err
+			}
+			for range allAlertConditionTags {
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					fmt.Sprintf("%d:%d", alertPolicy.ID, alertCondition.ID),
+					fmt.Sprintf("%s-%d", normalizeResourceName(alertCondition.Name), alertCondition.ID),
+					"newrelic_entity_tags",
+					g.ProviderName,
+					[]string{}))
+			}
+		}
+
+		for _, nrqlCondition := range nrqlConditions {
+			allNRQLConditionTags, err := client.Entities.GetTagsForEntityMutable(common.EntityGUID(fmt.Sprint(nrqlCondition.ID)))
+			if err != nil {
+				return err
+			}
+			for range allNRQLConditionTags {
+				g.Resources = append(g.Resources, terraformutils.NewSimpleResource(
+					fmt.Sprintf("%d:%d", alertPolicy.ID, nrqlCondition.ID),
+					fmt.Sprintf("%s-%d", normalizeResourceName(nrqlCondition.Name), nrqlCondition.ID),
+					"newrelic_entity_tags",
+					g.ProviderName,
+					[]string{}))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (g *TagsGenerator) InitResources() error {
+	client, err := g.Client()
+	if err != nil {
+		return err
+	}
+
+	funcs := []func(*newrelic.NewRelic) error{
+		g.createSyntheticsMonitorTagResources,
+		g.createAlertConditionTagResources,
+	}
+
+	for _, f := range funcs {
+		err := f(client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
* added tag importing, separated alert resources

- added tag importing
- separated alert resources in order to provide importing of only separate alert resources.

* updated tags.go

updated tags.go to address build errors.